### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Claude Desktop MCP server that helps you track flights in real-time using Flightradar24 data. Perfect for aviation enthusiasts, travel planners, or anyone curious about flights overhead!
 
+<a href="https://glama.ai/mcp/servers/5w29onbypp"><img width="380" height="200" src="https://glama.ai/mcp/servers/5w29onbypp/badge" alt="flightradar24-mcp-server MCP server" /></a>
+
 ## What Can This Do? ✨
 
 - 🔍 Track any flight in real-time


### PR DESCRIPTION
This PR adds a badge for the flightradar24-mcp-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/5w29onbypp"><img width="380" height="200" src="https://glama.ai/mcp/servers/5w29onbypp/badge" alt="flightradar24-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.